### PR TITLE
Add 1D MV-Convolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ there also exists the `GeometricSandwichProductDense` with an identical API.
 
 [Projective Geometric Algebra](https://github.com/RobinKa/tfga/tree/master/notebooks/pga.ipynb)
 
+[1D Multivector-valued Convolution Example](https://github.com/RobinKa/tfga/tree/master/notebooks/conv.ipynb)
+
 ## Tests
 Tests using Python's built-in `unittest` module are available in the `tests` directory. All tests can be run by
 executing `python -m unittest discover tests` from the root directory of the repository.

--- a/notebooks/conv.ipynb
+++ b/notebooks/conv.ipynb
@@ -1,0 +1,105 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import tensorflow as tf\n",
+    "# Make tensorflow not take over the entire GPU memory\n",
+    "for gpu in tf.config.experimental.list_physical_devices('GPU'):\n",
+    "    tf.config.experimental.set_memory_growth(gpu, True)\n",
+    "from tfga import GeometricAlgebra\n",
+    "from tfga.blades import BladeKind\n",
+    "from tfga.layers import GeometricProductConv1D"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "(2, 4, 4, 16)\ntf.Tensor(\n[[[[  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]\n   [  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]\n   [  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]\n   [  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]]\n\n  [[  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]\n   [  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]\n   [  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]\n   [  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]]\n\n  [[  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]\n   [  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]\n   [  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]\n   [  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]]\n\n  [[  0. -24.   0.  24.   0.  24.  24. -24.  24.   0.  24.  24.  24.\n     24.  24.  24.]\n   [  0. -24.   0.  24.   0.  24.  24. -24.  24.   0.  24.  24.  24.\n     24.  24.  24.]\n   [  0. -24.   0.  24.   0.  24.  24. -24.  24.   0.  24.  24.  24.\n     24.  24.  24.]\n   [  0. -24.   0.  24.   0.  24.  24. -24.  24.   0.  24.  24.  24.\n     24.  24.  24.]]]\n\n\n [[[  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]\n   [  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]\n   [  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]\n   [  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]]\n\n  [[  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]\n   [  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]\n   [  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]\n   [  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]]\n\n  [[  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]\n   [  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]\n   [  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]\n   [  0. -36.   0.  36.   0.  36.  36. -36.  36.   0.  36.  36.  36.\n     36.  36.  36.]]\n\n  [[  0. -24.   0.  24.   0.  24.  24. -24.  24.   0.  24.  24.  24.\n     24.  24.  24.]\n   [  0. -24.   0.  24.   0.  24.  24. -24.  24.   0.  24.  24.  24.\n     24.  24.  24.]\n   [  0. -24.   0.  24.   0.  24.  24. -24.  24.   0.  24.  24.  24.\n     24.  24.  24.]\n   [  0. -24.   0.  24.   0.  24.  24. -24.  24.   0.  24.  24.  24.\n     24.  24.  24.]]]], shape=(2, 4, 4, 16), dtype=float32)\n"
+    }
+   ],
+   "source": [
+    "ga = GeometricAlgebra([0, 1, 1, 1])\n",
+    "\n",
+    "batch_size = 2\n",
+    "sequence_length = 8\n",
+    "c_in = 3\n",
+    "c_out = 4\n",
+    "kernel_size = 3\n",
+    "\n",
+    "a = ga.from_tensor_with_kind(tf.ones([batch_size, sequence_length, c_in, ga.num_blades]), BladeKind.MV)\n",
+    "k = ga.from_tensor_with_kind(tf.ones([kernel_size, c_in, c_out, ga.num_blades]), BladeKind.MV)\n",
+    "\n",
+    "y = ga.geom_conv1d(a, k, 2, \"SAME\")\n",
+    "\n",
+    "print(y.shape)\n",
+    "print(y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "(2, 4, 4, 16)\nMultiVector[batch_shape=(2, 4, 4)]\nMultiVector[-0.86*1 + 0.12*e_0 + -0.86*e_1 + 0.24*e_2 + 0.55*e_3 + -1.85*e_01 + -1.05*e_02 + 2.10*e_03 + 0.24*e_12 + 0.55*e_13 + -1.29*e_23 + 1.53*e_012 + -1.01*e_013 + -1.56*e_023 + -1.29*e_123 + -1.02*e_0123]\n"
+    }
+   ],
+   "source": [
+    "mv_indices = tf.range(ga.num_blades, dtype=tf.int64)\n",
+    "\n",
+    "conv_layer = GeometricProductConv1D(\n",
+    "    ga, channels=c_out, kernel_size=kernel_size, stride=2, padding=\"SAME\",\n",
+    "    blade_indices_kernel=tf.range(ga.num_blades, dtype=tf.int64),\n",
+    "    blade_indices_bias=tf.range(ga.num_blades, dtype=tf.int64)\n",
+    ")\n",
+    "\n",
+    "y2 = conv_layer(a)\n",
+    "print(y2.shape)\n",
+    "ga.print(y2)\n",
+    "ga.print(y2[0, 0, 0])"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6-final"
+  },
+  "orig_nbformat": 2,
+  "kernelspec": {
+   "name": "python37664bittf2conda034469ea11204d31b38329519e9d7dbe",
+   "display_name": "Python 3.7.6 64-bit ('tf2': conda)"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tfga/layers.py
+++ b/tfga/layers.py
@@ -377,8 +377,7 @@ class GeometricConv1D(layers.Layer):
             trainable=True
         )
         if self.use_bias:
-            # TODO
-            shape_bias = [self.units, self.blade_indices_bias.shape[0]]
+            shape_bias = [self.channels, self.blade_indices_bias.shape[0]]
             self.bias = self.add_weight(
                 "bias",
                 shape=shape_bias,

--- a/tfga/mv_ops.py
+++ b/tfga/mv_ops.py
@@ -16,6 +16,58 @@ def mv_multiply(a_blade_values: tf.Tensor, b_blade_values: tf.Tensor,
     return x
 
 
+def mv_conv1d(a_blade_values: tf.Tensor, k_blade_values: tf.Tensor, cayley: tf.Tensor,
+              stride, padding, data_format="NWC", dilations=None) -> tf.Tensor:
+    # Winograd convolution
+
+    # A: [..., S, CI, BI]
+    # K: [K, CI, CO, BK]
+    # C: [BI, BK, BO]
+
+    kernel_size = k_blade_values.shape[0]
+
+    a_batch_shape = tf.shape(a_blade_values)[:-3]
+
+    # Reshape a_blade_values to a 2d image (since that's what the tf op expects)
+    # [*, S, 1, CI*BI]
+    a_image_shape = tf.concat([
+        a_batch_shape,
+        tf.shape(a_blade_values)[-3:-2],
+        [1, tf.reduce_prod(tf.shape(a_blade_values)[-2:])]
+    ], axis=0)
+    a_image = tf.reshape(a_blade_values, a_image_shape)
+
+    sizes = [1, kernel_size, 1, 1]
+    strides = [1, stride, 1, 1]
+
+    # [*, P, 1, K*CI*BI] where eg. number of patches P = S * K for
+    # stride=1 and "SAME", (S-K+1) * K for "VALID", ...
+    a_slices = tf.image.extract_patches(
+        a_image,
+        sizes=sizes, strides=strides,
+        rates=[1, 1, 1, 1], padding=padding
+    )
+
+    # [..., P, K, CI, BI]
+    out_shape = tf.concat(
+        [
+            a_batch_shape,
+            tf.shape(a_slices)[-3:-2],
+            tf.shape(k_blade_values)[:1],
+            tf.shape(a_blade_values)[-2:]
+        ],
+        axis=0
+    )
+
+    a_slices = tf.reshape(a_slices, out_shape)
+
+    # a_...p,k,ci,bi; k_k,ci,co,bk; c_bi,bk,bo -> y_...p,co,bo
+    #   ...a b c  d ,   e c  f  g ,   d  g  h  ->   ...a f  h
+    x = tf.einsum("...abcd,bcfg,dgh->...afh", a_slices, k_blade_values, cayley)
+
+    return x
+
+
 def mv_reversion(a_blade_values, algebra_blade_degrees):
     algebra_blade_degrees = tf.cast(algebra_blade_degrees, tf.float32)
 

--- a/tfga/mv_ops.py
+++ b/tfga/mv_ops.py
@@ -1,4 +1,5 @@
 """Operations on geometric algebra tensors used internally."""
+from typing import Union
 import tensorflow as tf
 
 
@@ -17,7 +18,8 @@ def mv_multiply(a_blade_values: tf.Tensor, b_blade_values: tf.Tensor,
 
 
 def mv_conv1d(a_blade_values: tf.Tensor, k_blade_values: tf.Tensor, cayley: tf.Tensor,
-              stride, padding, data_format="NWC", dilations=None) -> tf.Tensor:
+              stride: int, padding: str,
+              dilations: Union[int, None] = None) -> tf.Tensor:
     # Winograd convolution
 
     # A: [..., S, CI, BI]
@@ -58,6 +60,7 @@ def mv_conv1d(a_blade_values: tf.Tensor, k_blade_values: tf.Tensor, cayley: tf.T
 
     a_slices = tf.reshape(a_slices, out_shape)
 
+    # TODO: Optimize this to not use einsum (since it's slow with ellipses)
     # a_...p,k,ci,bi; k_k,ci,co,bk; c_bi,bk,bo -> y_...p,co,bo
     #   ...a b c  d ,   e c  f  g ,   d  g  h  ->   ...a f  h
     x = tf.einsum("...abcd,bcfg,dgh->...afh", a_slices, k_blade_values, cayley)

--- a/tfga/mv_ops.py
+++ b/tfga/mv_ops.py
@@ -49,15 +49,12 @@ def mv_conv1d(a_blade_values: tf.Tensor, k_blade_values: tf.Tensor, cayley: tf.T
     )
 
     # [..., P, K, CI, BI]
-    out_shape = tf.concat(
-        [
-            a_batch_shape,
-            tf.shape(a_slices)[-3:-2],
-            tf.shape(k_blade_values)[:1],
-            tf.shape(a_blade_values)[-2:]
-        ],
-        axis=0
-    )
+    out_shape = tf.concat([
+        a_batch_shape,
+        tf.shape(a_slices)[-3:-2],
+        tf.shape(k_blade_values)[:1],
+        tf.shape(a_blade_values)[-2:]
+    ], axis=0)
 
     a_slices = tf.reshape(a_slices, out_shape)
 

--- a/tfga/tfga.py
+++ b/tfga/tfga.py
@@ -15,7 +15,7 @@ from .blades import (
     BladeKind, get_blade_of_kind_indices, get_blade_indices_from_names,
     get_blade_repr, invert_blade_indices
 )
-from .mv_ops import mv_multiply, mv_reversion, mv_grade_automorphism
+from .mv_ops import mv_multiply, mv_reversion, mv_grade_automorphism, mv_conv1d
 from .mv import MultiVector
 
 
@@ -476,6 +476,12 @@ class GeometricAlgebra:
         b = tf.convert_to_tensor(b, dtype_hint=tf.float32)
 
         return mv_multiply(a, b, self._cayley_inner)
+
+    def geom_conv1d(self, a: tf.Tensor, k: tf.Tensor, stride: tf.Tensor, padding: str) -> tf.Tensor:
+        a = tf.convert_to_tensor(a, dtype_hint=tf.float32)
+        k = tf.convert_to_tensor(k, dtype_hint=tf.float32)
+
+        return mv_conv1d(a, k, self._cayley, stride=stride, padding=padding)
 
     def mv_repr(self, a: tf.Tensor) -> str:
         """Returns a string representation for the given

--- a/tfga/tfga.py
+++ b/tfga/tfga.py
@@ -477,7 +477,26 @@ class GeometricAlgebra:
 
         return mv_multiply(a, b, self._cayley_inner)
 
-    def geom_conv1d(self, a: tf.Tensor, k: tf.Tensor, stride: tf.Tensor, padding: str) -> tf.Tensor:
+    def geom_conv1d(self, a: tf.Tensor, k: tf.Tensor,
+                    stride: int, padding: str,
+                    dilations: Union[int, None] = None) -> tf.Tensor:
+        """Returns the 1D convolution of a sequence with a geometric algebra
+        tensor kernel. The convolution is performed using the geometric
+        product.
+
+        Args:
+            a: Input geometric algebra tensor of shape
+                [..., Length, ChannelsIn, Blades]
+            k: Geometric algebra tensor for the convolution kernel of shape
+                [ChannelsIn, ChannelsOut, KernelSize, Blades]
+            stride: Stride to use for the convolution
+            padding: "SAME" (zero-pad input length so output
+                length == input length / stride) or "VALID" (no padding)
+        Returns:
+            Geometric algbra tensor of shape
+            [..., OutputLength, ChannelsOut, Blades]
+            representing `a` convolved with `k`
+        """
         a = tf.convert_to_tensor(a, dtype_hint=tf.float32)
         k = tf.convert_to_tensor(k, dtype_hint=tf.float32)
 


### PR DESCRIPTION
Implements https://github.com/RobinKa/tfga/issues/8 (at least 1D convolution)

- Added `geom_conv1d` and keras layer `GeometricProductConv1D`
- Added convolution example notebook

Implemented using Winograd convolution which requires only a matmul implementation and a sliding window function. For the sliding window function [`extract_image_patches`](https://www.tensorflow.org/api_docs/python/tf/image/extract_patches) was used. This will also work for 2 dimensional convolution later. For 3 dimensions there is another function [`extract_volume_patches`](https://www.tensorflow.org/api_docs/python/tf/extract_volume_patches).